### PR TITLE
ARWorldTrackingSessionConfiguration is deprecated

### DIFF
--- a/ARKitRectangleDetection/ViewController.swift
+++ b/ARKitRectangleDetection/ViewController.swift
@@ -124,7 +124,7 @@ class ViewController: UIViewController, ARSCNViewDelegate, ARSessionDelegate {
         super.viewWillAppear(animated)
         
         // Create a session configuration
-        let configuration = ARWorldTrackingSessionConfiguration()
+        let configuration = ARWorldTrackingConfiguration()
         configuration.planeDetection = .horizontal
         
         // Run the view's session


### PR DESCRIPTION
ARWorldTrackingSessionConfiguration is deprecated. 

Replacing `ARWorldTrackingSessionConfiguration` with `ARWorldTrackingConfiguration` gets rid of the Xcode issue.